### PR TITLE
chore(deps): actualización de dependencias y configuración

### DIFF
--- a/.github/workflows/generate-docs.yml
+++ b/.github/workflows/generate-docs.yml
@@ -18,14 +18,14 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           fetch-depth: 0
 
-      - name: Set up JDK 24
-        uses: actions/setup-java@v4
+      - name: Set up JDK 25
+        uses: actions/setup-java@v5
         with:
-          java-version: '24'
+          java-version: '25'
           distribution: 'temurin'
           cache: maven
 
@@ -259,4 +259,4 @@ jobs:
     steps:
       - name: Deploy to GitHub Pages
         id: deployment
-        uses: actions/deploy-pages@v4
+        uses: actions/deploy-pages@v5

--- a/.github/workflows/maven.yml
+++ b/.github/workflows/maven.yml
@@ -13,24 +13,24 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           # Fetch all history for all branches and tags.
           # SonarCloud needs this to perform analysis on PRs.
           fetch-depth: 0
       - name: Set up JDK 25
-        uses: actions/setup-java@v4
+        uses: actions/setup-java@v5
         with:
           java-version: '25'
           distribution: 'temurin'
       - name: Cache SonarCloud packages
-        uses: actions/cache@v4
+        uses: actions/cache@v5
         with:
           path: ~/.sonar/cache
           key: ${{ runner.os }}-sonar
           restore-keys: ${{ runner.os }}-sonar
       - name: Cache Maven packages
-        uses: actions/cache@v4
+        uses: actions/cache@v5
         with:
           path: ~/.m2/repository
           key: ${{ runner.os }}-maven-${{ hashFiles('**/pom.xml') }}
@@ -54,17 +54,17 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Log in to Docker Hub
-        uses: docker/login-action@v3
+        uses: docker/login-action@v4
         with:
           username: ${{ secrets.DOCKER_USERNAME }}
           password: ${{ secrets.DOCKER_PASSWORD }}
 
       - name: Extract metadata for JVM Docker image
         id: meta-jvm
-        uses: docker/metadata-action@v5
+        uses: docker/metadata-action@v6
         with:
           images: ${{ secrets.DOCKER_IMAGE_NAME }}
           # Add a '-jvm' suffix to tags to differentiate them
@@ -75,10 +75,10 @@ jobs:
             latest
 
       - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v3
+        uses: docker/setup-buildx-action@v4
 
       - name: Build and push JVM Docker image
-        uses: docker/build-push-action@v6
+        uses: docker/build-push-action@v7
         with:
           context: .
           # Point to the new JVM-specific Dockerfile

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,17 @@ Todos los cambios notables en este proyecto serán documentados en este archivo.
 El formato está basado en [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 y este proyecto adhiere a [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.1.2] - 2026-04-04
+
+### Changed
+- Updated Spring Boot version to 4.0.5 (from 4.0.2)
+- Updated GitHub Actions to latest versions (checkout@v6, setup-java@v5, cache@v5, deploy-pages@v5, docker actions@v4-v7)
+- Updated Maven workflow Dockerfile configuration
+
+### Technical
+- Migrated from Eureka to Consul for service discovery (from previous release)
+- Updated Java version to 25
+
 ## [0.1.1] - 2026-02-03
 
 ### Changed

--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 ✒️ Autor: Daniel Quinteros
 
 ![Java](https://img.shields.io/badge/Java-25-orange)
-![Spring Boot](https://img.shields.io/badge/Spring%20Boot-4.0.2-brightgreen)
+![Spring Boot](https://img.shields.io/badge/Spring%20Boot-4.0.5-brightgreen)
 ![Spring Cloud](https://img.shields.io/badge/Spring%20Cloud-2025.1.0-brightgreen)
 ![Maven](https://img.shields.io/badge/Maven-3.9.x-red)
 ![License](https://img.shields.io/badge/License-MIT-blue)
@@ -18,8 +18,8 @@ Gateway Service para la arquitectura de microservicios de UM Tesorería. Este se
 ## Características Principales
 
 - Enrutamiento dinámico de solicitudes a múltiples servicios
-- Balanceo de carga con Eureka Client
-- Service discovery automático
+- Balanceo de carga con Consul Client
+- Service discovery automático con Consul
 - Control y monitoreo del tráfico
 - Caché optimizado con Caffeine
 - Documentación automática con GitHub Pages y Wiki
@@ -43,7 +43,7 @@ El gateway enruta las siguientes rutas a sus respectivos servicios:
 
 - Java 25
 - Maven 3.9.x o superior
-- Spring Boot 4.0.2
+- Spring Boot 4.0.5
 - Spring Cloud 2025.1.0
 - Docker (opcional, para contenedorización)
 

--- a/docs/diagrams/arquitectura-gateway.mmd
+++ b/docs/diagrams/arquitectura-gateway.mmd
@@ -17,10 +17,6 @@ graph TD
         Consul(Consul Server)
     end
 
-    subgraph "Configuration"
-        Config(Config Server)
-    end
-
     Client -->|1. Request /api/a/**| Gateway
     Gateway -->|2. Route to Service A| ServiceA
     Gateway -->|2. Route to Service B| ServiceB
@@ -31,11 +27,5 @@ graph TD
     ServiceB -->|Register/Discover| Consul
     ServiceC -->|Register/Discover| Consul
 
-    Gateway -->|Get Config| Config
-    ServiceA -->|Get Config| Config
-    ServiceB -->|Get Config| Config
-    ServiceC -->|Get Config| Config
-
     style Gateway fill:#f9f,stroke:#333,stroke-width:2px
     style Consul fill:#bbf,stroke:#333,stroke-width:2px
-    style Config fill:#fb9,stroke:#333,stroke-width:2px

--- a/pom.xml
+++ b/pom.xml
@@ -5,14 +5,14 @@
 	<parent>
 		<groupId>org.springframework.boot</groupId>
 		<artifactId>spring-boot-starter-parent</artifactId>
-		<version>4.0.2</version>
+		<version>4.0.5</version>
 		<relativePath/>
 		<!-- lookup parent from repository -->
 	</parent>
 
 	<groupId>ar.edu</groupId>
 	<artifactId>um.tesoreria.gateway-service</artifactId>
-	<version>0.1.1</version>
+	<version>0.1.2</version>
 	<name>UM.tesoreria.gateway-service</name>
 	<description>Spring Boot Microservice  Gateway</description>
 	<properties>


### PR DESCRIPTION
Closes #40

## Descripción
Actualización de dependencias y configuración del proyecto gateway-service. Incluye actualización de Spring Boot de 4.0.2 a 4.0.5, JDK de 24 a 25, y todas las GitHub Actions a sus últimas versiones.

## Cambios Realizados
- Actualizado Spring Boot de 4.0.2 a 4.0.5 (versión 0.1.1 → 0.1.2)
- Actualizado JDK de 24 a 25 en workflows de GitHub Actions
- Actualizado actions/checkout@v4 → @v6
- Actualizado actions/setup-java@v4 → @v5
- Actualizado actions/cache@v4 → @v5
- Actualizado actions/deploy-pages@v4 → @v5
- Actualizado docker/login-action@v3 → @v4
- Actualizado docker/metadata-action@v5 → @v6
- Actualizado docker/setup-buildx-action@v3 → @v4
- Actualizado docker/build-push-action@v6 → @v7
- Actualizado CHANGELOG.md con entrada para v0.1.2
- Actualizado README.md con versión de Spring Boot y referencias a Consul
- Actualizado diagrama de arquitectura (removido Config Server)

## Verificación
- Los workflows de GitHub Actions se ejecutan correctamente con las nuevas versiones
- El proyecto compila correctamente con JDK 25
- Los tests unitarios pasan correctamente
